### PR TITLE
Add ssh pwd, tagger from config, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+gat

--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -39,7 +39,7 @@ func makeBumpCmd(bumpType string) *cobra.Command {
 				handleError(err)
 
 				fmt.Printf("pushing %s to %s...\n", ref.Name(), remote)
-				err = push(repo, ref, remote, sshFile)
+				err = push(repo, ref, remote, sshFile, sshFilePassword)
 				handleError(err)
 
 				fmt.Println("done")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,9 +10,10 @@ import (
 )
 
 var (
-	dryrun  = false
-	remote  = ""
-	sshFile = ""
+	dryrun          = false
+	remote          = ""
+	sshFile         = ""
+	sshFilePassword = ""
 )
 
 func init() {
@@ -22,6 +23,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&dryrun, "dryrun", false, "avoid to touch current git repository")
 	rootCmd.PersistentFlags().StringVar(&remote, "remote", "origin", "origin where push to")
 	rootCmd.PersistentFlags().StringVar(&sshFile, "sshfile", usr.HomeDir+"/.ssh/id_rsa", "ssh file used to authenticate on git remote")
+	rootCmd.PersistentFlags().StringVar(&sshFilePassword, "sshpwd", "", "ssh file password")
 
 	rootCmd.AddCommand(makeBumpCmd("patch"))
 	rootCmd.AddCommand(makeBumpCmd("minor"))


### PR DESCRIPTION
## Description

- Add `.gitignore`: useful to filter out vendors and executables from commits;
- Add `sshpwd` cmd line param: necessary when dealing with ssh certificates with passphrase;
- Add `Tagger` parameter when tagging: with complex git configurations (as conditional configuration) the `go-git` library cannot read the tagger from a specific static (hardcoded) file. This PR uses the `git config` command that already implements this function.